### PR TITLE
fix module name to reflect reality

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module ic
+module github.com/Ragnaroek/import-check
 
 go 1.18


### PR DESCRIPTION
so `go install github.com/Ragnaroek/import-check@latest`
just works instead of reporting
```
go: github.com/Ragnaroek/import-check@latest: github.com/Ragnaroek/import-check@v0.0.0-20220724133534-dc0bd0998c37: parsing go.mod:
	module declares its path as: ic
	        but was required as: github.com/Ragnaroek/import-check
```